### PR TITLE
Add explicit exports to the main module

### DIFF
--- a/cwa/__init__.py
+++ b/cwa/__init__.py
@@ -1,7 +1,9 @@
-from .cwa import CwaEventDescription, generateQrCode, lowlevel
+from .cwa import CwaEventDescription, generateQrCode, generateUrl, generatePayload, lowlevel
 
 __all__ = [
     "CwaEventDescription",
     "generateQrCode",
+    "generateUrl",
+    "generatePayload",
     "lowlevel",
 ]

--- a/cwa/__init__.py
+++ b/cwa/__init__.py
@@ -1,0 +1,7 @@
+from .cwa import CwaEventDescription, generateQrCode, lowlevel
+
+__all__ = [
+    "CwaEventDescription",
+    "generateQrCode",
+    "lowlevel",
+]


### PR DESCRIPTION
I'm not a 100% sure on this since this isn't on PyPI and I just copied the ``cwa`` module as suggested in the README. However, I think the example in the README is wrong when it says

```
import cwa
…
eventDescription = cwa.CwaEventDescription()
```

It should either be

```
from cwa import cwa
```

Or the ``cwa`` main module should expose the public API directly, as this PR proposes.