### PR TITLE
Change Default to not Seed QR-Codes and provide Utility for custom rollover Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ venue** for at least 30 Minutes, to allow airborne particles to settle or get fi
 regarding a good time to rotate QR-Codes (i.e. always at 4:00 am) because they will fail so warn people in some
 important Situations (nightclubs, hotels, night-shift working) **without anyone noticing**.
 
-To disable rotation of QR-Codes, specify None as the Seed (Default behaviour). This Library gives you a utility to allow
-rotating QR-Codes at a time of day specified by your user:
+To disable rotation of QR-Codes, specify None as the Seed (Default behaviour).
+
+The Library also gives you a utility to allow rotating QR-Codes at a given time of the day. Please make
+sure to also integrate some kind of Secret into the seed, to prevent an adversary from calculating  future QR-Codes.
+The Secret *must stay constant* over time, or the resulting QR-Codes will not correctly trigger warnings.
 
 ```py
 import io
@@ -120,7 +123,8 @@ import cwa
 # Construct Event-Descriptor
 eventDescription = cwa.CwaEventDescription()
 # …
-eventDescription.seed = cwa.rolloverDate(datetime.now(), time(4, 0))
+seedDate = cwa.rolloverDate(datetime.now(), time(4, 0))
+eventDescription.seed = "Some Secret" + str(seedDate)
 ```
 
 this will keep the date-based seed until 4:00 am on the next day and only then roll over to the next day.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Use as follows:
 #!/usr/bin/env python3
 
 import io
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time, timedelta, timezone
 
-import cwa
+from cwa import cwa, rollover
 import qrcode.image.svg
 
+# Construct Event-Descriptor
 eventDescription = cwa.CwaEventDescription()
 eventDescription.locationDescription = 'Zuhause'
 eventDescription.locationAddress = 'Gau-Odernheim'
@@ -31,6 +32,11 @@ eventDescription.startDateTime = datetime.now(timezone.utc)
 eventDescription.endDateTime = datetime.now(timezone.utc) + timedelta(days=2)
 eventDescription.locationType = cwa.lowlevel.LOCATION_TYPE_PERMANENT_WORKPLACE
 eventDescription.defaultCheckInLengthInMinutes = 4 * 60
+
+# Renew QR-Code every night at 4:00
+eventDescription.seed = rollover.rolloverDate(datetime.now(), time(4, 0))
+
+# Generate QR-Code
 qr = cwa.generateQrCode(eventDescription)
 
 # Render QR-Code to PNG-File
@@ -75,13 +81,7 @@ CwaEventDescription
 	- `cwa.lowlevel.LOCATION_TYPE_TEMPORARY_PRIVATE_EVENT `= 11
 	- `cwa.lowlevel.LOCATION_TYPE_TEMPORARY_WORSHIP_SERVICE `= 12
 - `defaultCheckInLengthInMinutes`: Default Check-out time in minutes, Optional
-- `randomSeed`: Specific Seed, 16 Bytes, Optional, leave Empty if unsure, see Below for Explanation
-
-Random Seed
------------
-To mitigate [Profiling of Venues](https://github.com/corona-warn-app/cwa-documentation/blob/c0e2829/event_registration.md#profiling-of-venues), each QR-Code contains a 16 Bytes long random Seed Value, that makes each code even with the same data unique. This way a location can generate a fresh QR-Code each day and avoid the risk of being tracked.
-
-But sometimes it is important to be able to re-generate exactly the same code, e.g. from a database or other deterministic sources. If this is important to you, you can specify your own 16 bytes in the `randomSeed` Parameter of the `CwaEventDescription` object. You can easily generate it with [`secrets.token_bytes(16)`](https://docs.python.org/3/library/secrets.html#secrets.token_bytes).
+- `randomSeed`: Specific Seed
 
 Python 2/3
 ----------

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ From the [Documentation](https://github.com/corona-warn-app/cwa-documentation/bl
 > visitors can only warn each other **with the same QR code**.
 
 From an Application-Developers point of view, special care must be taken to decide if and when QR codes should be
-changed. A naive approach, i.e. changing the QR-Code every 5 Minutes, would render the complete Warning-Chain totally
+changed. A naive approach, i.e. changing the QR-Code on every call, would render the complete Warning-Chain totally
 useless **without anyone noticing**. Therefore, the Default of this Library as of 2021/04/26 is to **not seed the
 QR-Codes with random values**. This results in every QR-Code being generated without an explicit Seed to be identical,
 which minimizes the Risk of having QR-Codes that do not warn users as expected at the increased risk of profiling of

--- a/README.md
+++ b/README.md
@@ -81,7 +81,50 @@ CwaEventDescription
 	- `cwa.lowlevel.LOCATION_TYPE_TEMPORARY_PRIVATE_EVENT `= 11
 	- `cwa.lowlevel.LOCATION_TYPE_TEMPORARY_WORSHIP_SERVICE `= 12
 - `defaultCheckInLengthInMinutes`: Default Check-out time in minutes, Optional
-- `randomSeed`: Specific Seed
+- `seed`: Seed to rotate the QR-Code, Optional, `[str, bytes, int, float, date, datetime]` or `None` (Default).
+  **Use with caution & read below!** If unsure, leave blank.
+
+Rotating QR-Codes
+-----------------
+From the [Documentation](https://github.com/corona-warn-app/cwa-documentation/blob/master/event_registration.md):
+> Profiling of Venues
+>
+> An adversary can collect this information for a single venue by scanning the QR code and extracting and storing the
+> data. To mitigate the risk, CWA encourages owners to regularly generate new QR codes for their venues. The more
+> frequent QR codes are updated, the more difficult it is to keep a central database with venue data up-to-date.
+> **However**, a new QR code should only be generated **when no visitor is at the event or location**, because
+> visitors can only warn each other **with the same QR code**.
+
+From an Application-Developers point of view, special care must be taken to decide if and when QR codes should be
+changed. A naive approach, i.e. changing the QR-Code every 5 Minutes, would render the complete Warning-Chain totally
+useless **without anyone noticing**. Therefore, the Default of this Library as of 2021/04/26 is to **not seed the
+QR-Codes with random values**. This results in every QR-Code being generated without an explicit Seed to be identical,
+which minimizes the Risk of having QR-Codes that do not warn users as expected at the increased risk of profiling of
+Venues.
+
+As an Application-Developer you are encouraged to **ask you user if and when they want their QR-Codes to change** and
+explain to them that they should only rotate their Codes **when they are sure that nobody is at the location or in the
+venue** for at least 30 Minutes, to allow airborne particles to settle or get filtered out. Do **not make assumptions**
+regarding a good time to rotate QR-Codes (i.e. always at 4:00 am) because they will fail so warn people in some
+important Situations (nightclubs, hotels, night-shift working) **without anyone noticing**.
+
+To disable rotation of QR-Codes, specify None as the Seed (Default behaviour). This Library gives you a utility to allow
+rotating QR-Codes at a time of day specified by your user:
+
+```py
+import io
+from datetime import datetime, time
+
+import cwa
+
+# Construct Event-Descriptor
+eventDescription = cwa.CwaEventDescription()
+# …
+eventDescription.seed = cwa.rolloverDate(datetime.now(), time(4, 0))
+```
+
+this will keep the date-based seed until 4:00 am on the next day and only then roll over to the next day.
+See [test_rollover.py](cwa/test_rollover.py) for an in-depth look at the rollover code.
 
 Python 2/3
 ----------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use as follows:
 import io
 from datetime import datetime, time, timedelta, timezone
 
-from cwa import cwa, rollover
+import cwa
 import qrcode.image.svg
 
 # Construct Event-Descriptor
@@ -34,7 +34,7 @@ eventDescription.locationType = cwa.lowlevel.LOCATION_TYPE_PERMANENT_WORKPLACE
 eventDescription.defaultCheckInLengthInMinutes = 4 * 60
 
 # Renew QR-Code every night at 4:00
-eventDescription.seed = rollover.rolloverDate(datetime.now(), time(4, 0))
+eventDescription.seed = cwa.rolloverDate(datetime.now(), time(4, 0))
 
 # Generate QR-Code
 qr = cwa.generateQrCode(eventDescription)

--- a/cwa/__init__.py
+++ b/cwa/__init__.py
@@ -1,9 +1,11 @@
 from .cwa import CwaEventDescription, generateQrCode, generateUrl, generatePayload, lowlevel
+from .rollover import rolloverDate
 
 __all__ = [
     "CwaEventDescription",
     "generateQrCode",
     "generateUrl",
     "generatePayload",
+    "rolloverDate",
     "lowlevel",
 ]

--- a/cwa/cwa.py
+++ b/cwa/cwa.py
@@ -2,7 +2,7 @@ import base64
 from typing import Optional, Union
 
 import qrcode
-from datetime import datetime
+from datetime import datetime, date
 
 from . import cwa_pb2 as lowlevel
 from . import seed
@@ -50,7 +50,7 @@ class CwaEventDescription(object):
         self.defaultCheckInLengthInMinutes: Optional[int] = None
 
         """Specific Seed, Optional"""
-        self.seed: Union[str, bytes, int, float, datetime, None] = None
+        self.seed: Union[str, bytes, int, float, date, datetime, None] = None
 
 
 def generatePayload(eventDescription: CwaEventDescription) -> lowlevel.QRCodePayload:

--- a/cwa/cwa.py
+++ b/cwa/cwa.py
@@ -49,7 +49,10 @@ class CwaEventDescription(object):
         """Default Checkout-Time im Minutes, Optional"""
         self.defaultCheckInLengthInMinutes: Optional[int] = None
 
-        """Specific Seed, Optional"""
+        """Seed to rotate the QR-Code, Optional, [str, bytes, int, float, date, datetime] or None (Default)
+
+        Use with caution & read the Section about *Rotating QR-Codes* in the README first! If unsure, leave blank.
+        """
         self.seed: Union[str, bytes, int, float, date, datetime, None] = None
 
 

--- a/cwa/cwa.py
+++ b/cwa/cwa.py
@@ -1,11 +1,11 @@
 import base64
-import random
 from typing import Optional, Union
 
 import qrcode
 from datetime import datetime
 
 from . import cwa_pb2 as lowlevel
+from . import seed
 
 PUBLIC_KEY_STR = 'gwLMzE153tQwAOf2MZoUXXfzWTdlSpfS99iZffmcmxOG9njSK4RTimFOFwDh6t0Tyw8XR01ugDYjtuKwj' \
                  'juK49Oh83FWct6XpefPi9Skjxvvz53i9gaMmUEc96pbtoaA'
@@ -53,18 +53,6 @@ class CwaEventDescription(object):
         self.seed: Union[str, bytes, int, float, datetime, None] = None
 
 
-def constructSeed(seed: Union[str, bytes, int, float, datetime, None]) -> bytes:
-    if seed is None:
-        seed = b''
-
-    elif isinstance(seed, datetime):
-        seed = str(seed)
-
-    r = random.Random()
-    r.seed(seed)
-    return bytes([r.randrange(0, 256) for _ in range(0, 16)])
-
-
 def generatePayload(eventDescription: CwaEventDescription) -> lowlevel.QRCodePayload:
     payload = lowlevel.QRCodePayload()
     payload.version = 1
@@ -79,7 +67,7 @@ def generatePayload(eventDescription: CwaEventDescription) -> lowlevel.QRCodePay
 
     payload.crowdNotifierData.version = 1
     payload.crowdNotifierData.publicKey = PUBLIC_KEY
-    payload.crowdNotifierData.cryptographicSeed = constructSeed(eventDescription.seed)
+    payload.crowdNotifierData.cryptographicSeed = seed.constructSeed(eventDescription.seed)
 
     cwaLocationData = lowlevel.CWALocationData()
     cwaLocationData.version = 1

--- a/cwa/cwa.py
+++ b/cwa/cwa.py
@@ -62,7 +62,7 @@ def constructSeed(seed: Union[str, bytes, int, float, datetime, None]) -> bytes:
 
     r = random.Random()
     r.seed(seed)
-    return r.randbytes(16)
+    return bytes([r.randrange(0, 256) for _ in range(0, 16)])
 
 
 def generatePayload(eventDescription: CwaEventDescription) -> lowlevel.QRCodePayload:

--- a/cwa/rollover.py
+++ b/cwa/rollover.py
@@ -4,6 +4,6 @@ from datetime import datetime, date, time, timedelta
 def rolloverDate(dt: datetime, rollover: time) -> date:
     given_time = dt.time()
     if given_time < rollover:
-        return dt.date()
+        return dt.date() - timedelta(days=1)
     else:
-        return dt.date() + timedelta(days=1)
+        return dt.date()

--- a/cwa/rollover.py
+++ b/cwa/rollover.py
@@ -1,0 +1,9 @@
+from datetime import datetime, date, time, timedelta
+
+
+def rolloverDate(dt: datetime, rollover: time) -> date:
+    given_time = dt.time()
+    if given_time < rollover:
+        return dt.date()
+    else:
+        return dt.date() + timedelta(days=1)

--- a/cwa/seed.py
+++ b/cwa/seed.py
@@ -1,0 +1,15 @@
+import random
+from datetime import datetime
+from typing import Union
+
+
+def constructSeed(seed: Union[str, bytes, int, float, datetime, None]) -> bytes:
+    if seed is None:
+        seed = b''
+
+    elif isinstance(seed, datetime):
+        seed = str(seed)
+
+    r = random.Random()
+    r.seed(seed)
+    return bytes([r.randrange(0, 256) for _ in range(0, 16)])

--- a/cwa/seed.py
+++ b/cwa/seed.py
@@ -1,13 +1,11 @@
 import random
-from datetime import datetime
-from typing import Union
 
 
-def constructSeed(seed: Union[str, bytes, int, float, datetime, None]) -> bytes:
+def constructSeed(seed) -> bytes:
     if seed is None:
         seed = b''
 
-    elif isinstance(seed, datetime):
+    if type(seed) not in [int, float, str, bytes]:
         seed = str(seed)
 
     r = random.Random()

--- a/cwa/test_cwa.py
+++ b/cwa/test_cwa.py
@@ -1,5 +1,4 @@
 import io
-import secrets
 from datetime import datetime, timedelta, timezone
 
 import qrcode
@@ -28,17 +27,58 @@ def test_generate_with_all_parameters():
     assert url != ''
 
 
-def test_generate_without_given_seed_creates_different_results():
-    urlA = cwa.generateUrl(fullEventDescription)
-    urlB = cwa.generateUrl(fullEventDescription)
-    assert urlA != urlB
-
-
-def test_generate_wit_given_seed_creates_same_result():
-    fullEventDescription.randomSeed = secrets.token_bytes(16)
+def test_generate_without_seed_creates_same_results():
     urlA = cwa.generateUrl(fullEventDescription)
     urlB = cwa.generateUrl(fullEventDescription)
     assert urlA == urlB
+
+
+def test_generate_with_same_seed_creates_same_result():
+    fullEventDescription.seed = 'a'
+    urlA = cwa.generateUrl(fullEventDescription)
+    urlB = cwa.generateUrl(fullEventDescription)
+    assert urlA == urlB
+
+
+def test_generate_with_different_seeds_creates_different_results():
+    fullEventDescription.seed = 'a'
+    urlA = cwa.generateUrl(fullEventDescription)
+
+    fullEventDescription.seed = 'b'
+    urlB = cwa.generateUrl(fullEventDescription)
+
+    assert urlA != urlB
+
+
+def assert_accepts_seed(seed):
+    seedA = cwa.constructSeed(seed)
+    seedB = cwa.constructSeed(seed)
+    assert len(seedA) == 16
+    assert seedA == seedB
+
+
+def test_accepts_int_seed():
+    assert_accepts_seed(42)
+
+
+def test_accepts_float_seed():
+    assert_accepts_seed(3.1415)
+
+
+def test_accepts_str_seed():
+    assert_accepts_seed('foo')
+
+
+def test_accepts_datetime_seed():
+    assert_accepts_seed(datetime(2021, 4, 21, 10, 0))
+
+
+def test_accepts_bytes_seed():
+    assert_accepts_seed(b'\xDE\xAD\xBE\xEF')
+
+
+def test_accepts_none_seed():
+    assert_accepts_seed(None)
 
 
 def test_generate_url():

--- a/cwa/test_cwa.py
+++ b/cwa/test_cwa.py
@@ -50,37 +50,6 @@ def test_generate_with_different_seeds_creates_different_results():
     assert urlA != urlB
 
 
-def assert_accepts_seed(seed):
-    seedA = cwa.constructSeed(seed)
-    seedB = cwa.constructSeed(seed)
-    assert len(seedA) == 16
-    assert seedA == seedB
-
-
-def test_accepts_int_seed():
-    assert_accepts_seed(42)
-
-
-def test_accepts_float_seed():
-    assert_accepts_seed(3.1415)
-
-
-def test_accepts_str_seed():
-    assert_accepts_seed('foo')
-
-
-def test_accepts_datetime_seed():
-    assert_accepts_seed(datetime(2021, 4, 21, 10, 0))
-
-
-def test_accepts_bytes_seed():
-    assert_accepts_seed(b'\xDE\xAD\xBE\xEF')
-
-
-def test_accepts_none_seed():
-    assert_accepts_seed(None)
-
-
 def test_generate_url():
     url = cwa.generateUrl(fullEventDescription)
     assert url is not None

--- a/cwa/test_rollover.py
+++ b/cwa/test_rollover.py
@@ -1,0 +1,27 @@
+from datetime import datetime, time, date
+
+from . import rollover
+
+
+def test_rollover():
+    rollover_time = time(13, 0)
+
+    # before 13:00 it's the given day
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 0, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 6, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 12, 0), rollover_time) == date(2021, 1, 1)
+
+    # after 13:00 it's the next day
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 13, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 16, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 20, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 59), rollover_time) == date(2021, 1, 2)
+
+    # and it continues to be the next day until 13:00
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 0, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 6, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 12, 0), rollover_time) == date(2021, 1, 2)
+
+    # then it's the day after
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 13, 0), rollover_time) == date(2021, 1, 3)

--- a/cwa/test_rollover.py
+++ b/cwa/test_rollover.py
@@ -4,24 +4,33 @@ from . import rollover
 
 
 def test_rollover():
-    rollover_time = time(13, 0)
+    rollover_time = time(4, 0)
 
-    # before 13:00 it's the given day
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 0, 0), rollover_time) == date(2021, 1, 1)
+    # between 4:00 and 23:59 it's the given day
     assert rollover.rolloverDate(datetime(2021, 1, 1, 6, 0), rollover_time) == date(2021, 1, 1)
     assert rollover.rolloverDate(datetime(2021, 1, 1, 12, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 20, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 22, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 59), rollover_time) == date(2021, 1, 1)
 
-    # after 13:00 it's the next day
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 13, 0), rollover_time) == date(2021, 1, 2)
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 16, 0), rollover_time) == date(2021, 1, 2)
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 20, 0), rollover_time) == date(2021, 1, 2)
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 0), rollover_time) == date(2021, 1, 2)
-    assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 59), rollover_time) == date(2021, 1, 2)
 
-    # and it continues to be the next day until 13:00
-    assert rollover.rolloverDate(datetime(2021, 1, 2, 0, 0), rollover_time) == date(2021, 1, 2)
-    assert rollover.rolloverDate(datetime(2021, 1, 2, 6, 0), rollover_time) == date(2021, 1, 2)
+    # between 0:00 and 4:00 on the following day, it's still the day before
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 0, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 2, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 3, 0), rollover_time) == date(2021, 1, 1)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 3, 59), rollover_time) == date(2021, 1, 1)
+
+    # after 4:00 it's the next day
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 4, 0), rollover_time) == date(2021, 1, 2)
     assert rollover.rolloverDate(datetime(2021, 1, 2, 12, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 20, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 23, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 2, 23, 59), rollover_time) == date(2021, 1, 2)
+
+    # and it continues to be the next day until 4:00
+    assert rollover.rolloverDate(datetime(2021, 1, 3, 0, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 3, 2, 0), rollover_time) == date(2021, 1, 2)
+    assert rollover.rolloverDate(datetime(2021, 1, 3, 3, 59), rollover_time) == date(2021, 1, 2)
 
     # then it's the day after
-    assert rollover.rolloverDate(datetime(2021, 1, 2, 13, 0), rollover_time) == date(2021, 1, 3)
+    assert rollover.rolloverDate(datetime(2021, 1, 3, 4, 0), rollover_time) == date(2021, 1, 3)

--- a/cwa/test_rollover.py
+++ b/cwa/test_rollover.py
@@ -13,7 +13,6 @@ def test_rollover():
     assert rollover.rolloverDate(datetime(2021, 1, 1, 22, 0), rollover_time) == date(2021, 1, 1)
     assert rollover.rolloverDate(datetime(2021, 1, 1, 23, 59), rollover_time) == date(2021, 1, 1)
 
-
     # between 0:00 and 4:00 on the following day, it's still the day before
     assert rollover.rolloverDate(datetime(2021, 1, 2, 0, 0), rollover_time) == date(2021, 1, 1)
     assert rollover.rolloverDate(datetime(2021, 1, 2, 2, 0), rollover_time) == date(2021, 1, 1)

--- a/cwa/test_seed.py
+++ b/cwa/test_seed.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from . import seed
+
+
+def assert_accepts_seed(value):
+    seedA = seed.constructSeed(value)
+    seedB = seed.constructSeed(value)
+    assert len(seedA) == 16
+    assert seedA == seedB
+
+
+def test_accepts_int_seed():
+    assert_accepts_seed(42)
+
+
+def test_accepts_float_seed():
+    assert_accepts_seed(3.1415)
+
+
+def test_accepts_str_seed():
+    assert_accepts_seed('foo')
+
+
+def test_accepts_datetime_seed():
+    assert_accepts_seed(datetime(2021, 4, 21, 10, 0))
+
+
+def test_accepts_bytes_seed():
+    assert_accepts_seed(b'\xDE\xAD\xBE\xEF')
+
+
+def test_accepts_none_seed():
+    assert_accepts_seed(None)

--- a/example.py
+++ b/example.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time, timedelta, timezone
 
-from cwa import cwa
+from cwa import cwa, rollover
 
+# Construct Event-Descriptor
 eventDescription = cwa.CwaEventDescription()
 eventDescription.locationDescription = 'Zuhause'
 eventDescription.locationAddress = 'Gau-Odernheim'
@@ -11,6 +12,17 @@ eventDescription.startDateTime = datetime.now(timezone.utc)
 eventDescription.endDateTime = datetime.now(timezone.utc) + timedelta(days=2)
 eventDescription.locationType = cwa.lowlevel.LOCATION_TYPE_PERMANENT_WORKPLACE
 eventDescription.defaultCheckInLengthInMinutes = 4 * 60
+
+# Renew QR-Code every night at 4:00
+seed = rollover.rolloverDate(datetime.now(), time(4, 0))
+print("seed", seed)
+eventDescription.seed = seed
+
+# Generate URL for Debugging purpose
+url = cwa.generateUrl(eventDescription)
+print('url', url)
+
+# Generate QR-Code
 qr = cwa.generateQrCode(eventDescription)
 
 img = qr.make_image(fill_color="black", back_color="white")

--- a/example.py
+++ b/example.py
@@ -14,9 +14,9 @@ eventDescription.locationType = cwa.lowlevel.LOCATION_TYPE_PERMANENT_WORKPLACE
 eventDescription.defaultCheckInLengthInMinutes = 4 * 60
 
 # Renew QR-Code every night at 4:00
-seed = cwa.rolloverDate(datetime.now(), time(4, 0))
-print("seed", seed)
-eventDescription.seed = seed
+seedDate = eventDescription.seed = cwa.rolloverDate(datetime.now(), time(4, 0))
+print("seedDate", seedDate)
+eventDescription.seed = "Some Secret" + str(seedDate)
 
 # Generate URL for Debugging purpose
 url = cwa.generateUrl(eventDescription)

--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, time, timedelta, timezone
 
-from cwa import cwa, rollover
+import cwa
 
 # Construct Event-Descriptor
 eventDescription = cwa.CwaEventDescription()
@@ -14,7 +14,7 @@ eventDescription.locationType = cwa.lowlevel.LOCATION_TYPE_PERMANENT_WORKPLACE
 eventDescription.defaultCheckInLengthInMinutes = 4 * 60
 
 # Renew QR-Code every night at 4:00
-seed = rollover.rolloverDate(datetime.now(), time(4, 0))
+seed = cwa.rolloverDate(datetime.now(), time(4, 0))
 print("seed", seed)
 eventDescription.seed = seed
 


### PR DESCRIPTION
From the [Documentation](https://github.com/corona-warn-app/cwa-documentation/blob/master/event_registration.md):
> Profiling of Venues
>
> An adversary can collect this information for a single venue by scanning the QR code and extracting and storing the
> data. To mitigate the risk, CWA encourages owners to regularly generate new QR codes for their venues. The more
> frequent QR codes are updated, the more difficult it is to keep a central database with venue data up-to-date.
> **However**, a new QR code should only be generated **when no visitor is at the event or location**, because
> visitors can only warn each other **with the same QR code**.

From an Application-Developers point of view, special care must be taken to decide if and when QR codes should be
changed. A naive approach, i.e. changing the QR-Code on every call, would render the complete Warning-Chain totally
useless **without anyone noticing**. Therefore, the Default of this Library changed in this PR is to **not seed the
QR-Codes with random values**. This results in every QR-Code being generated without an explicit Seed to be identical,
which minimizes the Risk of having QR-Codes that do not warn users as expected at the increased risk of profiling of
Venues.

As an Application-Developer you are encouraged to **ask you user if and when they want their QR-Codes to change** and
explain to them that they should only rotate their Codes **when they are sure that nobody is at the location or in the
venue** for at least 30 Minutes, to allow airborne particles to settle or get filtered out. Do **not make assumptions**
regarding a good time to rotate QR-Codes (i.e. always at 4:00 am) because they will fail so warn people in some
important Situations (nightclubs, hotels, night-shift working) **without anyone noticing**.

To disable rotation of QR-Codes, specify None as the Seed (Default behaviour). This PR gives authors a utility to allow
rotating QR-Codes at a time of day specified by your user:

```py
import io
from datetime import datetime, time

import cwa

# Construct Event-Descriptor
eventDescription = cwa.CwaEventDescription()
# …
eventDescription.seed = cwa.rolloverDate(datetime.now(), time(4, 0))
```

this will keep the date-based seed until 4:00 am on the next day and only then roll over to the next day.
See [test_rollover.py](cwa/test_rollover.py) for an in-depth look at the rollover code.
