### PR TITLE
Loosen version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "Pillow==8.3.2",
-        "protobuf==3.15.8",
-        "qrcode==6.1",
-        "six==1.15.0",
-        "svgutils==0.3.4",
+        "Pillow==8.*",
+        "protobuf==3.*",
+        "qrcode==6.*",
+        "six>=1.15.0",
+        "svgutils==0.3.*",
     ],
     zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "Pillow==8.*",
-        "protobuf==3.*",
-        "qrcode==6.*",
+        "Pillow",
+        "protobuf",
+        "qrcode",
         "six>=1.15.0",
-        "svgutils==0.3.*",
+        "svgutils",
     ],
     zip_safe=True,
 )


### PR DESCRIPTION
It makes sense for a Python project to pin specific versions, but it can be annoying for a dependency. In our case, we could not use cwa-qr in an environment where we also use protobuf 3.19, even though they work fine together. I therefore propose loosening the constraint.